### PR TITLE
Renamed repository

### DIFF
--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -4,7 +4,7 @@ Clyde is a language for writing game dialogues. It supports branching dialogues,
 
 It was heavily inspired by [Ink](https://github.com/inkle/ink), but it focuses on dialogues instead of narratives.
 
-You can play with the online editor [here](https://viniciusgerevini.github.io/clyde/).
+You can play with the online editor [here](https://viniciusgerevini.github.io/clyde-js/).
 
 ### Principles
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Clyde - Dialogue Language
 
-![Parser and Interpreter tests](https://github.com/viniciusgerevini/clyde/actions/workflows/main.yml/badge.svg?branch=master)
-![Editor tests](https://github.com/viniciusgerevini/clyde/actions/workflows/editor.yml/badge.svg?branch=master)
-![Playground deploy](https://github.com/viniciusgerevini/clyde/actions/workflows/gh_pages.yml/badge.svg?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/viniciusgerevini/clyde/badge.svg?branch=master)](https://coveralls.io/github/viniciusgerevini/clyde?branch=master)
+![Parser and Interpreter tests](https://github.com/viniciusgerevini/clyde-js/actions/workflows/main.yml/badge.svg?branch=master)
+![Editor tests](https://github.com/viniciusgerevini/clyde-js/actions/workflows/editor.yml/badge.svg?branch=master)
+![Playground deploy](https://github.com/viniciusgerevini/clyde-js/actions/workflows/gh_pages.yml/badge.svg?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/viniciusgerevini/clyde-js/badge.svg?branch=master)](https://coveralls.io/github/viniciusgerevini/clyde-js?branch=master)
 
 <p align="center"><img src="icon.png" alt=/></p>
 
@@ -11,7 +11,7 @@ Clyde is a language for writing game dialogues. It supports branching dialogues,
 
 It was heavily inspired by [Ink](https://github.com/inkle/ink), but it focuses on dialogues instead of narratives.
 
-You can play with the online editor [here](https://viniciusgerevini.github.io/clyde/).
+You can play with the online editor [here](https://viniciusgerevini.github.io/clyde-js/).
 
 Here is a simple dialogue:
 ```
@@ -75,5 +75,5 @@ I originally created the editor for the demo page, but I know no custom editor w
 
 ### Online Editor and Interpreter
 
-[Playground page](https://viniciusgerevini.github.io/clyde/).
+[Playground page](https://viniciusgerevini.github.io/clyde-js/).
 

--- a/editor/README.md
+++ b/editor/README.md
@@ -1,4 +1,4 @@
 # Clyde Editor
 
-Web editor used on live [playground](https://viniciusgerevini.github.io/clyde/).
+Web editor used on live [playground](https://viniciusgerevini.github.io/clyde-js/).
 

--- a/editor/package.json
+++ b/editor/package.json
@@ -2,7 +2,7 @@
   "name": "clyde-editor",
   "version": "2.1.0",
   "private": true,
-  "homepage": "https://viniciusgerevini.github.io/clyde",
+  "homepage": "https://viniciusgerevini.github.io/clyde-js",
   "dependencies": {
     "@clyde-lang/interpreter": "4.0.1",
     "@clyde-lang/parser": "2.3.2",

--- a/editor/public/manifest.json
+++ b/editor/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Clyde Editor",
+  "name": "Clyde Editor",
   "icons": [
     {
       "src": "favicon.ico",

--- a/editor/src/WebsiteApp.tsx
+++ b/editor/src/WebsiteApp.tsx
@@ -40,9 +40,9 @@ export default function WebsiteApp() {
         <AboutContent>
           <p>
             Clyde is a language for writing dialogues.
-            <a href="https://github.com/viniciusgerevini/clyde">Github</a>
-            <a href="https://github.com/viniciusgerevini/clyde/blob/master/LANGUAGE.md">Language Docs</a>
-            <a href="https://github.com/viniciusgerevini/clyde/tree/master/cli">CLI</a>
+            <a href="https://github.com/viniciusgerevini/clyde-js">Github</a>
+            <a href="https://github.com/viniciusgerevini/clyde/blob/main/LANGUAGE.md">Language Docs</a>
+            <a href="https://github.com/viniciusgerevini/clyde-js/tree/master/cli">CLI</a>
             <a href="https://github.com/viniciusgerevini/godot-clyde-dialogue">Godot Plugin</a>
           </p>
         </AboutContent>

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/%40clyde-lang%2Finterpreter.svg)](https://www.npmjs.com/package/@clyde-lang/interpreter)
 
 
-Interpreter library for [Clyde dialogue language](https://github.com/viniciusgerevini/clyde/blob/master/LANGUAGE.md).
+Interpreter library for [Clyde dialogue language](https://github.com/viniciusgerevini/clyde/blob/main/LANGUAGE.md).
 
 ```javascript
 import { parse } from '@clyde-lang/parser';


### PR DESCRIPTION
Renaming this repository to clyde-js as it holds the NodeJS/Web interpreter. The clyde repository now will be only for the language definition, to prevent confusion for people looking for the Godot plugin.