### PR TITLE
Allow more chars in tags and ids

### DIFF
--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+### Added
+
+- Support speaker blocks
+```
+Vinny:
+    Multiple lines can be set with same speaker.
+    You just need to indent them after the speaker line.
+    Grouping lines also work this way
+        by indenting the line further.
+```
+
+### Changed
+
+- Tags now accept `.` and `-` also.
+
 ## 2.3.2 (2024-06-20)
 
 ### Fixed

--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -18,6 +18,7 @@ Vinny:
 ### Changed
 
 - Tags now accept `.` and `-` also.
+- Variables now can start with `_`.
 
 ## 2.3.2 (2024-06-20)
 

--- a/parser/src/lexer.spec.ts
+++ b/parser/src/lexer.spec.ts
@@ -536,7 +536,7 @@ hello
 { variable == true }
 { variable == false }
 { variable == "s1" }
-{ variable == null }
+{ _variable == null }
 { @global_variable }
 
 `).getAll();
@@ -701,11 +701,11 @@ hello
 
       { token: TOKENS.LINE_BREAK, line: 23, column: 0, },
       { token: TOKENS.BRACE_OPEN, line: 23, column: 0, },
-      { token: TOKENS.IDENTIFIER, value: 'variable', line: 23, column: 2, },
-      { token: TOKENS.EQUAL, line: 23, column: 11, },
-      { token: TOKENS.NULL_TOKEN, line: 23, column: 14, },
-      { token: TOKENS.BRACE_CLOSE, line: 23, column: 19, },
-      { token: TOKENS.LINE_BREAK, line: 23, column: 20, },
+      { token: TOKENS.IDENTIFIER, value: '_variable', line: 23, column: 2, },
+      { token: TOKENS.EQUAL, line: 23, column: 12, },
+      { token: TOKENS.NULL_TOKEN, line: 23, column: 15, },
+      { token: TOKENS.BRACE_CLOSE, line: 23, column: 20, },
+      { token: TOKENS.LINE_BREAK, line: 23, column: 21, },
 
       { token: TOKENS.LINE_BREAK, line: 24, column: 0,  },
       { token: TOKENS.BRACE_OPEN, line: 24, column: 0, },

--- a/parser/src/lexer.spec.ts
+++ b/parser/src/lexer.spec.ts
@@ -366,13 +366,13 @@ speaker1: this is something $123&var1
 
   it('tags', () => {
     const tokens = tokenize(`
-this is something #hello #happy #something_else
+this is something #hello #happy.mm #something-else
 `).getAll();
     expect(tokens).toEqual([
       { token: TOKENS.TEXT, value: 'this is something', line: 1, column: 0 },
       { token: TOKENS.TAG, value: 'hello', line: 1, column: 18 },
-      { token: TOKENS.TAG, value: 'happy', line: 1, column: 25 },
-      { token: TOKENS.TAG, value: 'something_else', line: 1, column: 32 },
+      { token: TOKENS.TAG, value: 'happy.mm', line: 1, column: 25 },
+      { token: TOKENS.TAG, value: 'something-else', line: 1, column: 35 },
       { token: TOKENS.EOF, line: 2, column: 0 },
     ]);
   });

--- a/parser/src/lexer.ts
+++ b/parser/src/lexer.ts
@@ -363,7 +363,7 @@ export function tokenize(input: string): TokenList {
     position += 1;
     column += 1;
 
-    while (input[position] && input[position].match(/[A-Z|a-z|0-9|_]/)) {
+    while (input[position] && input[position].match(/[A-Z|a-z|0-9|_|\-|\.]/)) {
       values.push(input[position]);
       position += 1;
       column += 1;

--- a/parser/src/lexer.ts
+++ b/parser/src/lexer.ts
@@ -704,7 +704,7 @@ export function tokenize(input: string): TokenList {
       return handleLogicNumber();
     }
 
-    if (input[position].match(/[A-Za-z@]/)) {
+    if (input[position].match(/[A-Za-z@_]/)) {
       return handleLogicIdentifier();
     }
   };


### PR DESCRIPTION
- Tags now also accept `.` and `-`.
- Variables now can start with `_`.