### PR TITLE
Events with parameters

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+### Changed
+
+- Support events with parameters (e.g `{ trigger event(param1, param2, "text", ...) }`)
+
+
 ## 3.1.0 (2024-10-07)
 
 ### Added

--- a/interpreter/CHANGELOG.md
+++ b/interpreter/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+### Changed
+
+- Support events with parameters (e.g `{ trigger event(param1, param2, "text", ...) }`)
+
+
 ## 4.1.0 (2024-10-07)
 
 ### Breaking changes

--- a/interpreter/src/interpreter.spec.ts
+++ b/interpreter/src/interpreter.spec.ts
@@ -80,6 +80,22 @@ describe("Interpreter", () => {
 
       dialogue.getContent()
     });
+
+    it('trigger dialogue event with parameters', (done) => {
+      const content = parse('Hi! {set a = 1 }{ trigger some_event(a, "test", true, a + 1) }\n');
+      const dialogue = Interpreter(content);
+
+      dialogue.on(EventType.EVENT_TRIGGERED, (data: any) => {
+        try {
+          expect(data).toEqual({ name:'some_event', parameters: [1, "test", true, 2 ] });
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+
+      dialogue.getContent()
+    });
   });
 
   describe('persistence', () => {

--- a/interpreter/src/interpreter.ts
+++ b/interpreter/src/interpreter.ts
@@ -458,11 +458,7 @@ export function Interpreter(
   };
 
   const handleEventNode = (events: EventsNode) => {
-    events.events.forEach((event: EventNode) => {
-      listeners.triggerEvent(
-        EventType.EVENT_TRIGGERED,
-        { name: event.name });
-    });
+    triggerEvents(events);
     return handleNextNode(stackHead().current);
   };
 
@@ -553,14 +549,22 @@ export function Interpreter(
 
   const handleAction = (actionNode: ActionContentNode) => {
     if (actionNode.action.type === 'events') {
-      (actionNode.action as EventsNode).events.forEach((event: EventNode) => {
-        listeners.triggerEvent(
-          EventType.EVENT_TRIGGERED,
-          { name: event.name });
-      });
+      triggerEvents(actionNode.action as EventsNode);
     } else {
       (actionNode.action as AssignmentsNode).assignments.forEach(logic.handleAssignement)
     }
+  }
+
+  const triggerEvents = (events: EventsNode) => {
+    events.events.forEach((event: EventNode) => {
+      listeners.triggerEvent(
+        EventType.EVENT_TRIGGERED,
+        {
+          name: event.name,
+          parameters: event.params?.map(logic.getNodeValue),
+        }
+      );
+    });
   }
 
   const handleConditionalContent = (conditionalNode: ConditionalContentNode, fallbackNode = stackHead().current) => {

--- a/interpreter/src/logic_interpreter.ts
+++ b/interpreter/src/logic_interpreter.ts
@@ -12,6 +12,7 @@ import { MemoryManager } from './memory';
 
 export interface LogicInterpreterInstance {
   checkCondition(condition: OperandNode): any;
+  getNodeValue(source: any): any;
   handleAssignement(assignment: AssignmentNode): any;
 }
 
@@ -84,6 +85,7 @@ export const LogicInterpreter = (mem: MemoryManager): LogicInterpreterInstance =
 
   return {
     checkCondition,
+    getNodeValue,
     handleAssignement,
   };
 };

--- a/parser/CHANGELOG.md
+++ b/parser/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+### Changed
+
+- Support events with parameters (e.g `{ trigger event(param1, param2, "text", ...) }`)
+
 ## 2.4.0 (2024-10-07)
 
 ### Added

--- a/parser/src/lexer.spec.ts
+++ b/parser/src/lexer.spec.ts
@@ -976,6 +976,7 @@ hello
 { trigger event_name }
 { trigger event_name, event_name_2 }
 { trigger event_name(param_1, "text", 1, true) }
+{ trigger event_name(param_1 + 1) }
 `).getAll();
     expect(tokens).toEqual([
       { token: TOKENS.LINE_BREAK, line: 1, column: 0 },
@@ -1010,7 +1011,19 @@ hello
       { token: TOKENS.BRACE_CLOSE, line: 3, column: 47, },
       { token: TOKENS.LINE_BREAK, line: 3, column: 48 },
 
-      { token: TOKENS.EOF, line: 4, column: 0 },
+      { token: TOKENS.LINE_BREAK, line: 4, column: 0 },
+      { token: TOKENS.BRACE_OPEN, line: 4, column: 0, },
+      { token: TOKENS.KEYWORD_TRIGGER, line: 4, column: 2, },
+      { token: TOKENS.IDENTIFIER, value: 'event_name', line: 4, column: 10, },
+      { token: TOKENS.BRACKET_OPEN, line: 4, column: 20, },
+      { token: TOKENS.IDENTIFIER, value: 'param_1', line: 4, column: 21, },
+      { token: TOKENS.PLUS, line: 4, column: 29, },
+      { token: TOKENS.NUMBER_LITERAL, value: '1', line: 4, column: 31, },
+      { token: TOKENS.BRACKET_CLOSE, line: 4, column: 32, },
+      { token: TOKENS.BRACE_CLOSE, line: 4, column: 34, },
+      { token: TOKENS.LINE_BREAK, line: 4, column: 35 },
+
+      { token: TOKENS.EOF, line: 5, column: 0 },
     ]);
   });
 

--- a/parser/src/lexer.spec.ts
+++ b/parser/src/lexer.spec.ts
@@ -971,6 +971,49 @@ hello
     ]);
   });
 
+  it('events trigger', () => {
+    const tokens = tokenize(`
+{ trigger event_name }
+{ trigger event_name, event_name_2 }
+{ trigger event_name(param_1, "text", 1, true) }
+`).getAll();
+    expect(tokens).toEqual([
+      { token: TOKENS.LINE_BREAK, line: 1, column: 0 },
+      { token: TOKENS.BRACE_OPEN, line: 1, column: 0, },
+      { token: TOKENS.KEYWORD_TRIGGER, line: 1, column: 2, },
+      { token: TOKENS.IDENTIFIER, value: 'event_name', line: 1, column: 10, },
+      { token: TOKENS.BRACE_CLOSE, line: 1, column: 21, },
+      { token: TOKENS.LINE_BREAK, line: 1, column: 22 },
+
+      { token: TOKENS.LINE_BREAK, line: 2, column: 0 },
+      { token: TOKENS.BRACE_OPEN, line: 2, column: 0, },
+      { token: TOKENS.KEYWORD_TRIGGER, line: 2, column: 2, },
+      { token: TOKENS.IDENTIFIER, value: 'event_name', line: 2, column: 10, },
+      { token: TOKENS.COMMA, line: 2, column: 20, },
+      { token: TOKENS.IDENTIFIER, value: 'event_name_2', line: 2, column: 22, },
+      { token: TOKENS.BRACE_CLOSE, line: 2, column: 35, },
+      { token: TOKENS.LINE_BREAK, line: 2, column: 36 },
+
+      { token: TOKENS.LINE_BREAK, line: 3, column: 0 },
+      { token: TOKENS.BRACE_OPEN, line: 3, column: 0, },
+      { token: TOKENS.KEYWORD_TRIGGER, line: 3, column: 2, },
+      { token: TOKENS.IDENTIFIER, value: 'event_name', line: 3, column: 10, },
+      { token: TOKENS.BRACKET_OPEN, line: 3, column: 20, },
+      { token: TOKENS.IDENTIFIER, value: 'param_1', line: 3, column: 21, },
+      { token: TOKENS.COMMA, line: 3, column: 28, },
+      { token: TOKENS.STRING_LITERAL, value: 'text', line: 3, column: 30, },
+      { token: TOKENS.COMMA, line: 3, column: 36, },
+      { token: TOKENS.NUMBER_LITERAL, value: '1', line: 3, column: 38, },
+      { token: TOKENS.COMMA, line: 3, column: 39, },
+      { token: TOKENS.BOOLEAN_LITERAL, value: 'true', line: 3, column: 41, },
+      { token: TOKENS.BRACKET_CLOSE, line: 3, column: 45, },
+      { token: TOKENS.BRACE_CLOSE, line: 3, column: 47, },
+      { token: TOKENS.LINE_BREAK, line: 3, column: 48 },
+
+      { token: TOKENS.EOF, line: 4, column: 0 },
+    ]);
+  });
+
   it('includes line break when just after or before a logic block', () => {
 
     const tokens = tokenize(`

--- a/parser/src/lexer.ts
+++ b/parser/src/lexer.ts
@@ -690,6 +690,14 @@ export function tokenize(input: string): TokenList {
       return handleLogicBlockStop();
     }
 
+    if (input[position] === '(') {
+      return createSimpleToken(TOKENS.BRACKET_OPEN, 1);
+    }
+
+    if (input[position] === ')') {
+      return createSimpleToken(TOKENS.BRACKET_CLOSE, 1);
+    }
+
     if (checkSequence(input, position, '==')) {
       return handleLogicOperator(TOKENS.EQUAL, 2);
     }

--- a/parser/src/nodes.ts
+++ b/parser/src/nodes.ts
@@ -154,7 +154,7 @@ export class EventsNode {
 
 export class EventNode {
   public type = 'event';
-  constructor (public name: string) {};
+  constructor (public name: string, public params: Array<OperandNode> | undefined = undefined) {};
 }
 
 export type LogicBlockNode = ConditionalContentNode | ActionContentNode;

--- a/parser/src/parser-logic.spec.ts
+++ b/parser/src/parser-logic.spec.ts
@@ -1,7 +1,7 @@
 import parse from './parser';
 
 describe('parse: logic', () => {
-  const createDocPayload = (content = [], blocks = []) => {
+  const createDocPayload = (content: Array<any> = [], blocks = []) => {
     return {
       type: 'document',
       content: [{
@@ -930,6 +930,41 @@ describe('parse: logic', () => {
         action: {
           type: 'events',
           events: [{ type: 'event', name: 'some_event' }],
+        },
+        content: {
+          type: 'line',
+          value: 'trigger',
+        },
+      }]);
+      expect(result).toEqual(expected);
+    });
+
+    it('trigger event with parameters', () => {
+      const result = parse(`{ trigger some_event(this_is_a_var, this_is_a_var + 1, 123, "text", false) } trigger`);
+      const expected = createDocPayload([{
+        type: 'action_content',
+        action: {
+          type: 'events',
+          events: [
+            {
+              type: 'event',
+              name: 'some_event',
+              params: [
+                { type: 'variable', name: 'this_is_a_var' },
+                {
+                  type: 'expression',
+                  name: 'add',
+                  elements: [
+                    { type: 'variable', name: 'this_is_a_var', },
+                    { type: 'literal', name: 'number', value: 1 },
+                  ],
+                },
+                { type: 'literal', name: 'number', value: 123 },
+                { type: 'literal', name: 'string', value: "text" },
+                { type: 'literal', name: 'boolean', value: false },
+              ]
+            }
+          ],
         },
         content: {
           type: 'line',

--- a/parser/src/parser.ts
+++ b/parser/src/parser.ts
@@ -691,17 +691,36 @@ export default function parse(doc: string): ClydeDocumentRoot {
   const Events = (): EventsNode => {
     consume([TOKENS.KEYWORD_TRIGGER]);
     consume([TOKENS.IDENTIFIER]);
-    const events = [new EventNode(currentToken.value)];
+    const events = [Event(currentToken.value)];
 
     while(peek([TOKENS.COMMA])) {
       consume([TOKENS.COMMA]);
       consume([TOKENS.IDENTIFIER]);
-      events.push(new EventNode(currentToken.value));
+      events.push(Event(currentToken.value));
     }
 
     consume([TOKENS.BRACE_CLOSE]);
 
     return new EventsNode(events);
+  };
+
+  const Event = (eventName: string): EventNode => {
+    if (!peek([TOKENS.BRACKET_OPEN])) {
+      return new EventNode(eventName);
+    }
+
+    consume([TOKENS.BRACKET_OPEN]);
+
+    const params = [Expression()];
+
+    while(peek([TOKENS.COMMA])) {
+      consume([TOKENS.COMMA]);
+      params.push(Expression());
+    }
+
+    consume([TOKENS.BRACKET_CLOSE]);
+
+    return new EventNode(eventName, params);
   };
 
   const ConditionalLine = (): ConditionalContentNode => {


### PR DESCRIPTION
Allow passing parameters to events, as defined in the language spec 3.2.0
```
-- you can pass literal arguments
{ trigger my_event("some text", 1, true) }

-- you can pass variables
{ trigger my_event(this_is_a_variable) }

-- and even expressions
{ trigger my_event(some_important_count + something_else) }
```